### PR TITLE
Add function to Open app info settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ Add a `NotificationScheduler` node to your scene and follow the following steps:
 	$NotificationScheduler.request_post_notifications_permission()
 ```
 - `permission_granted` signal will be emitted when the application receives the permissions
-
+> On Android, apps that target Android 13 or higher can ask for notification permission as many times as they want until the user explicitly denies the permission twice. If the user targets Android 12 or lower, the app can ask for permission as many times as it wants until the user denies the permission once. If the user denies the permission twice, the app can't ask again unless the user reinstalls the app
+- After user has denied the request, you can ask to turn on notification permission manually and send them to App_Info screen using the `NotificationScheduler` node:(Best Practice: Don't promt users automatically, insted keep a button in settings to toggle notifications)
+```
+	$NotificationScheduler.open_app_info_settings()
+```
 - Create a notification channel using the `NotificationScheduler` node:
 ```
 	$NotificationScheduler.create_notification_channel(

--- a/notification/addon_template/NotificationScheduler.gd
+++ b/notification/addon_template/NotificationScheduler.gd
@@ -83,6 +83,11 @@ func request_post_notifications_permission() -> void:
 	else:
 		printerr("%s singleton not initialized!" % PLUGIN_SINGLETON_NAME)
 
+func open_app_info_settings() -> void:
+	if _plugin_singleton:
+		_plugin_singleton.open_app_info_settings()
+	else:
+		printerr("%s singleton not initialized!" % PLUGIN_SINGLETON_NAME)
 
 func _on_notification_opened(a_notification_id: int) -> void:
 	notification_opened.emit(a_notification_id)

--- a/notification/src/main/java/org/godotengine/plugin/android/notification/NotificationSchedulerPlugin.java
+++ b/notification/src/main/java/org/godotengine/plugin/android/notification/NotificationSchedulerPlugin.java
@@ -20,6 +20,8 @@ import android.icu.util.Calendar;
 import android.os.Build;
 import android.util.Log;
 import android.view.View;
+import android.provider.Settings;
+import android.net.Uri;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -181,6 +183,24 @@ public class NotificationSchedulerPlugin extends GodotPlugin {
 			}
 		} catch (Exception e) {
 			Log.e(LOG_TAG, "request_post_notifications_permission():: Failed to request permission due to " + e.getMessage());
+		}
+	}
+
+	/**
+	 * Opens APP INFO settings screen
+	 */
+	@UsedByGodot
+	public void open_app_info_settings() {
+		Log.d(LOG_TAG, "open_app_info_settings()");
+		
+		try {
+			Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+			intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+			Uri uri = Uri.fromParts("package", activity.getPackageName(), null);
+			intent.setData(uri);
+			activity.startActivity(intent);
+		} catch (Exception e) {
+			Log.e(LOG_TAG, "open_app_info_settings():: Failed due to "+ e.getMessage());
 		}
 	}
 


### PR DESCRIPTION
*I have created this for my own use, but I think it will be beneficial for everyone*

---
> On Android, apps that target Android 13 or higher can ask for notification permission as many times as they want until the user explicitly denies the permission twice. If the user targets Android 12 or lower, the app can ask for permission as many times as it wants until the user denies the permission once. If the user denies the permission twice, the app can't ask again unless the user reinstalls the app

- This will be helpful if after denying permission, user wants to turns on notification for any reason (eg. notification regarding game energy recharge, app update, purchage completed etc.)
- This adds functionality to open App Info screen directly from app, which allow users to set permission easily.